### PR TITLE
fix: mobile share

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,15 +7,13 @@ import Keyboard from './components/keyboard/Keyboard'
 
 // TODO:
 // MVP
-// - MAKE IT WORK ON MOBILE
 // - get answer based on date
-// - styling
 // - feedback for invalid guess
 // 2.0
 // - animate letter input
 // - LONGER WORDS for a true MMO challenge
-//   - word get longer as the week goes on?
-//   - one really long word for the whole week?
+//   * word get longer as the week goes on?
+//   * one really long word for the whole week?
 
 function App() {
   const { guess, setGuess, result, isSubmitted, submit } = useGameState()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ function App() {
   }
 
   return (
-    <div className='pt-28 gap-4 h-screen flex flex-col items-center'>
+    <div className='pt-52 gap-4 h-screen flex flex-col items-center'>
       <p>{'You only get one guess >:)'}</p>
       <Row guess={guess} result={result} isSubmitted={isSubmitted} />
       <Keyboard addChar={addChar} delChar={delChar} submit={submit} />

--- a/src/components/CopyResultsButton.tsx
+++ b/src/components/CopyResultsButton.tsx
@@ -24,6 +24,7 @@ function CopyResultsButton({
   function copy() {
     const text = `${spreadGuess}\n${emojis.join('')}`
     try {
+      // turns out, both of these work fine on mobile, as long as you're on HTTPS
       if (!!navigator.clipboard && !!navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text).then(() => {
           alert(`Copied to clipboard:\n\n${text}`)
@@ -40,17 +41,6 @@ function CopyResultsButton({
       alert(ERROR_MESSAGE)
     }
   }
-  // function copy() {
-  //   const text = `${spreadGuess}\n${emojis.join('')}`
-  //   navigator.clipboard
-  //     .writeText(text)
-  //     .then(() => {
-  //       alert(`Copied to clipboard:\n\n${text}`)
-  //     })
-  //     .catch(() => {
-  //       alert('Oops, something went wrong')
-  //     })
-  // }
 
   return (
     <Button

--- a/src/components/CopyResultsButton.tsx
+++ b/src/components/CopyResultsButton.tsx
@@ -22,18 +22,19 @@ function CopyResultsButton({
   const spreadGuess = spread(guess)
 
   function copy() {
-    let hasShared = false
     const text = `${spreadGuess}\n${emojis.join('')}`
     try {
       if (!!navigator.clipboard && !!navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text).then(() => {
-          hasShared = true
           alert(`Copied to clipboard:\n\n${text}`)
         })
+        return
       }
-      if (!hasShared && !!navigator.share && navigator.canShare({ text })) {
+      if (!!navigator.share && navigator.canShare({ text })) {
         navigator.share({ text })
+        return
       }
+
       alert(ERROR_MESSAGE)
     } catch (_) {
       alert(ERROR_MESSAGE)

--- a/src/components/CopyResultsButton.tsx
+++ b/src/components/CopyResultsButton.tsx
@@ -4,6 +4,9 @@ import { cn } from '../lib/utils'
 import copyIcon from '../assets/copy-solid.svg'
 import Button from './Button'
 
+const ERROR_MESSAGE =
+  "Oops, something went wrong.\n\nPlease let the admin know what device and browser you're using so they can fix the bug <3"
+
 interface CopyResultsButtonProps {
   className?: string
   guess: string
@@ -19,12 +22,21 @@ function CopyResultsButton({
   const spreadGuess = spread(guess)
 
   function copy() {
+    let hasShared = false
     const text = `${spreadGuess}\n${emojis.join('')}`
     try {
-      navigator.share({ text }).catch((error) => alert(error.message))
-    } catch (error) {
-      //@ts-ignore
-      alert(error.message)
+      if (!!navigator.clipboard && !!navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(() => {
+          hasShared = true
+          alert(`Copied to clipboard:\n\n${text}`)
+        })
+      }
+      if (!hasShared && !!navigator.share && navigator.canShare({ text })) {
+        navigator.share({ text })
+      }
+      alert(ERROR_MESSAGE)
+    } catch (_) {
+      alert(ERROR_MESSAGE)
     }
   }
   // function copy() {

--- a/src/components/CopyResultsButton.tsx
+++ b/src/components/CopyResultsButton.tsx
@@ -20,14 +20,32 @@ function CopyResultsButton({
 
   function copy() {
     const text = `${spreadGuess}\n${emojis.join('')}`
-    navigator.clipboard.writeText(text)
-    alert(`Copied to clipboard:\n\n${text}`)
+    try {
+      navigator.share({ text }).catch((error) => alert(error.message))
+    } catch (error) {
+      //@ts-ignore
+      alert(error.message)
+    }
   }
+  // function copy() {
+  //   const text = `${spreadGuess}\n${emojis.join('')}`
+  //   navigator.clipboard
+  //     .writeText(text)
+  //     .then(() => {
+  //       alert(`Copied to clipboard:\n\n${text}`)
+  //     })
+  //     .catch(() => {
+  //       alert('Oops, something went wrong')
+  //     })
+  // }
 
   return (
     <Button
       onClick={copy}
-      className={cn('bg-green-result text-white', className)}
+      className={cn(
+        'bg-green-result active:bg-green-700 text-white',
+        className
+      )}
     >
       <CopyIcon /> Copy Result
     </Button>


### PR DESCRIPTION
Not *really* a fix. Both methods (`navigator.share()` and `navigator.clipboard.writeText()`) only work over HTTPS on mobile.

Also adds better positioning (padding) and an active state for the Copy button

Note: use mkcert to use HTTPS locally